### PR TITLE
Xcode project generation improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.DS_Store
+
 build.ios
 build.sim
 build.sim64
+Xcode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,7 @@ set_target_properties(${APP_NAME} PROPERTIES
 
 #include framework headers
 target_include_directories(${APP_NAME} PUBLIC 
-    "${PROJECT_BINARY_DIR}/cppframework/$<CONFIG>${CMAKE_XCODE_EFFECTIVE_PLATFORMS}/${FRAMEWORK_NAME}.framework"
+    "${PROJECT_BINARY_DIR}/cppframework/\${CONFIGURATION}\${EFFECTIVE_PLATFORM_NAME}/${FRAMEWORK_NAME}.framework"
 )
 
 
@@ -139,7 +139,7 @@ add_custom_command(
     TARGET
     ${APP_NAME}
     POST_BUILD COMMAND ${CMAKE_COMMAND} -E make_directory
-    ${PROJECT_BINARY_DIR}/$<CONFIG>${CMAKE_XCODE_EFFECTIVE_PLATFORMS}/${APP_NAME}.app/Frameworks
+    ${PROJECT_BINARY_DIR}/\${CONFIGURATION}\${EFFECTIVE_PLATFORM_NAME}/${APP_NAME}.app/Frameworks
 )
 
 # Copy the framework into the bundle
@@ -147,8 +147,8 @@ add_custom_command(
     TARGET
     ${APP_NAME}
     POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${PROJECT_BINARY_DIR}/cppframework/$<CONFIG>${CMAKE_XCODE_EFFECTIVE_PLATFORMS}/
-    ${PROJECT_BINARY_DIR}/$<CONFIG>${CMAKE_XCODE_EFFECTIVE_PLATFORMS}/${APP_NAME}.app/Frameworks
+    ${PROJECT_BINARY_DIR}/cppframework/\${CONFIGURATION}\${EFFECTIVE_PLATFORM_NAME}/
+    ${PROJECT_BINARY_DIR}/\${CONFIGURATION}\${EFFECTIVE_PLATFORM_NAME}/${APP_NAME}.app/Frameworks
 )
 
 # Codesign the framework in it's new spot
@@ -156,7 +156,7 @@ add_custom_command(
     TARGET
     ${APP_NAME}
     POST_BUILD COMMAND codesign --force --verbose
-    ${PROJECT_BINARY_DIR}/$<CONFIG>${CMAKE_XCODE_EFFECTIVE_PLATFORMS}/${APP_NAME}.app/Frameworks/${FRAMEWORK_NAME}.framework
-    --sign \"iPhone Developer\"
+    ${PROJECT_BINARY_DIR}/\${CONFIGURATION}\${EFFECTIVE_PLATFORM_NAME}/${APP_NAME}.app/Frameworks/${FRAMEWORK_NAME}.framework
+    --sign ${CODESIGNIDENTITY}
 )
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a blank single-view-controller iOS app and C++ dynamically linked framework which use CMake to create an Xcode-friendly out-of-source build system. Instead of configuring the build system through an `.xcodeproj` file, you instead maintain a set of `CMakeLists.txt` files describing the build system.
 
-This CMake project can do everything Xcode can; eg build the executable app & the C++ library in `cppframework`. The build systems, generated into `build.ios` `build.sim` `build.sim64` are gitignored. CMakeLists.txt file is the only build configuration kept in source control. This is in contrast to committing the `.xcodeproj` directory which includes the backing XML, which is nonsensically hard to edit by hand.
+This CMake project can do everything Xcode can; eg build the executable app & the C++ library in `cppframework`. The build systems, generated into `build.ios` `build.sim` `build.sim64` `Xcode` are gitignored. CMakeLists.txt file is the only build configuration kept in source control. This is in contrast to committing the `.xcodeproj` directory which includes the backing XML, which is nonsensically hard to edit by hand.
 
 The app instantiates a C++ object from the dynamically linked framework and calls a function on it. It subsequently deletes the C++ object pointer.
 
@@ -18,15 +18,19 @@ The app instantiates a C++ object from the dynamically linked framework and call
   - NOTE: the build `./build-ios.sh` will fail if you don't have provisioning profiles for the current bundle identifier. It uses the `set(CODESIGNIDENTITY "iPhone Developer")` identity to use the default certificate for the current bundle identifier.
 - Requires CMake version 3.7
 
-#### Create Xcode project for Devices (armv7, armv7s, arm64)
+#### Create Xcode project for Devices (armv7, armv7s, arm64) and Simulators (i386, x86_64)
+- Run `generate-project.sh` to create Xcode project in `Xcode`
+- Run `open Xcode/project.xcodeproj`
+
+#### Create & build Xcode project for Devices (armv7, armv7s, arm64)
 - Run `build-ios.sh` to generate the build system in `build.ios/`
 - Run `open build.ios/project.xcodeproj`
 
-#### Create Xcode project for Simulator 32-bit (i386)
+#### Create & build Xcode project for Simulator 32-bit (i386)
 - Run `build-sim.sh` to build the build system in `build.sim/`
 - Run `open build.sim/project.xcodeproj`
 
-#### Create Xcode project for Simulator 64-bit (x86_64)
+#### Create & build Xcode project for Simulator 64-bit (x86_64)
 - Run `build-sim64.sh` 
 - Run `open build.sim64/project.xcodeproj`
 

--- a/generate-project.sh
+++ b/generate-project.sh
@@ -1,0 +1,1 @@
+cmake -DCMAKE_TOOLCHAIN_FILE=./ios.cmake -DIOS_PLATFORM=OS -H. -BXcode -GXcode


### PR DESCRIPTION
1.  Project generated for IOS_PLATFORM=OS can now be used to run
    on iOS simulator + on all configurations without regenerating
    project.
2.  Signing for cppframework is now using CODESIGNIDENTITY variable.
3.  Separate project generation script file has been added.
4.  .gitignore has been updated to ignore new build system directory
    Xcode and .DS_Store files created by Finder.