### PR TITLE
Test setup example has been added.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,17 +2,21 @@ cmake_minimum_required (VERSION 3.7)
 
 set(DEVELOPMENT_PROJECT_NAME "project")                     # <== Set to your project name, e.g. project.xcodeproj
 set(DEVELOPMENT_TEAM_ID "AAAAAAAAAA")                       # <== Set to your team ID from Apple
-set(APP_NAME "YOURAPP")                                     # <== Set To Your app's name
+set(APP_NAME "YOURAPP")                                     # <== Set To your app's name
 set(APP_BUNDLE_IDENTIFIER "com.company.app")                # <== Set to your app's bundle identifier
 set(FRAMEWORK_NAME "FooBar")                                # <== Set to your framework's name
 set(FRAMEWORK_BUNDLE_IDENTIFIER "com.company.framework")    # <== Set to your framework's bundle ID
+set(TEST_NAME "Tests")                                      # <== Set to your test's name
+set(TEST_BUNDLE_IDENTIFIER "com.company.tests")             # <== Set to your tests's bundle ID
 set(CODE_SIGN_IDENTITY "iPhone Developer")                  # <== Set to your preferred code sign identity, to see list:
                                                             # /usr/bin/env xcrun security find-identity -v -p codesigning
 set(DEPLOYMENT_TARGET 8.0)                                  # <== Set your deployment target version of iOS
 set(DEVICE_FAMILY "1")                                      # <== Set to "1" to target iPhone, set to "2" to target iPad, set to "1,2" to target both
+set(LOGIC_ONLY_TESTS 0)                                     # <== Set to 1 if you do not want tests to be hosted by the application, speeds up pure logic tests but you can not run them on real devices
 
 project(${DEVELOPMENT_PROJECT_NAME})
 include(BundleUtilities)
+include(FindXCTest)
 
 set(PRODUCT_NAME ${APP_NAME})
 set(EXECUTABLE_NAME ${APP_NAME})
@@ -86,6 +90,9 @@ add_executable(
 add_subdirectory(cppframework)
 add_dependencies(${APP_NAME} ${FRAMEWORK_NAME})
 
+# Build tests
+add_subdirectory(tests)
+
 # Locate system libraries on iOS
 find_library(UIKIT UIKit)
 find_library(FOUNDATION Foundation)
@@ -120,8 +127,11 @@ set_target_properties(${APP_NAME} PROPERTIES
                       XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY ${DEVICE_FAMILY}
                       MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/plist.in
                       XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES
-                      XCODE_ATTRIBUTE_COMBINE_HIDPI_IMAGES "NO"
-                      XCODE_ATTRIBUTE_INSTALL_PATH "$(LOCAL_APPS_DIR)")
+                      XCODE_ATTRIBUTE_COMBINE_HIDPI_IMAGES NO
+                      XCODE_ATTRIBUTE_INSTALL_PATH "$(LOCAL_APPS_DIR)"
+                      XCODE_ATTRIBUTE_ENABLE_TESTABILITY YES
+                      XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN YES
+)
 
 # Include framework headers, needed to make "Build" Xcode action work.
 # "Archive" works fine just relying on default search paths as it has different

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # CMake Build Configuration for iOS
 
-This is a blank single-view-controller iOS app and C++ dynamically linked framework which use CMake to create an Xcode-friendly out-of-source build system. Instead of configuring the build system through an `.xcodeproj` file, you instead maintain a set of `CMakeLists.txt` files describing the build system.
+This is a blank single-view-controller iOS app, C++ dynamically linked framework and example tests which use CMake to create an Xcode-friendly out-of-source build system. Instead of configuring the build system through an `.xcodeproj` file, you instead maintain a set of `CMakeLists.txt` files describing the build system.
 
-This CMake project can do everything Xcode can; eg build the executable app & the C++ library in `cppframework`. The build systems, generated into `build.ios` `build.sim` `build.sim64` `Xcode` are gitignored. CMakeLists.txt file is the only build configuration kept in source control. This is in contrast to committing the `.xcodeproj` directory which includes the backing XML, which is nonsensically hard to edit by hand.
+This CMake project can do everything Xcode can; eg build the executable app & the C++ library in `cppframework`. The build systems, generated into `build.ios` `build.sim` `build.sim64` `Xcode` are gitignored. CMakeLists.txt files are the only build configuration kept in source control. This is in contrast to committing the `.xcodeproj` directory which includes the backing XML, which is nonsensically hard to edit by hand.
 
 The app instantiates a C++ object from the dynamically linked framework and calls a function on it. It subsequently deletes the C++ object pointer.
+
+The test instantiates ObjC object of class `CppInterface` from the app and checks that it exists.
 
 ## What can this do for me?
 - Conveniently use external C/C++/Objective-C libraries built with CMake in your app. Just clone the library and add an `add_subdirectory` to build that dependent library according to it's own build system, but directly as a target in your app's build system.
@@ -14,7 +16,7 @@ The app instantiates a C++ object from the dynamically linked framework and call
 
 ### To Use:
 - Open `CMakeLists.txt`
-  - Set lines 3-11 with values for your project
+  - Set lines 3-15 with values for your project
   - NOTE: the build `./build-ios.sh` will fail if you don't have provisioning profiles for the current bundle identifier. It uses the `set(CODESIGNIDENTITY "iPhone Developer")` identity to use the default certificate for the current bundle identifier.
 - Requires CMake version 3.7
 
@@ -35,7 +37,7 @@ The app instantiates a C++ object from the dynamically linked framework and call
 - Run `open build.sim64/project.xcodeproj`
 
 #### iPhone/iPad
-- The app target builds to iPhone device family. To build an iPhone/iPad target, change the value of `DEVICE_FAMILY` on line 12 of `CMakeLists.txt` to `"1,2"`
+- The app target builds to iPhone device family. To build an iPhone/iPad target, change the value of `DEVICE_FAMILY` on line 14 of `CMakeLists.txt` to `"1,2"`
 
 ### Framework
 - Builds a dynamically linked iOS framework for the architectures relevant to the platform

--- a/cppframework/CMakeLists.txt
+++ b/cppframework/CMakeLists.txt
@@ -29,6 +29,12 @@ set_target_properties(${FRAMEWORK_NAME} PROPERTIES
     XCODE_ATTRIBUTE_SKIP_INSTALL "YES"
 )
 
+# Symbol visibility setup, COMPILE_FLAGS only affect C++ so for Objective C we
+# have to use XCODE_ATTRIBUTE_OTHER_CFLAGS.
+set_target_properties(${FRAMEWORK_NAME} PROPERTIES
+    COMPILE_FLAGS "-fvisibility=hidden -fvisibility-inlines-hidden"
+    XCODE_ATTRIBUTE_OTHER_CFLAGS "-fvisibility=hidden -fvisibility-inlines-hidden")
+
 # set_target_properties(${FRAMEWORK_NAME} PROPERTIES COMPILE_FLAGS "-x c++")
 
 add_custom_command(

--- a/ios.cmake
+++ b/ios.cmake
@@ -37,9 +37,8 @@ set (CMAKE_C_OSX_CURRENT_VERSION_FLAG "-current_version ")
 set (CMAKE_CXX_OSX_COMPATIBILITY_VERSION_FLAG "${CMAKE_C_OSX_COMPATIBILITY_VERSION_FLAG}")
 set (CMAKE_CXX_OSX_CURRENT_VERSION_FLAG "${CMAKE_C_OSX_CURRENT_VERSION_FLAG}")
 
-# Hidden visibilty is required for cxx on iOS 
 set (CMAKE_C_FLAGS_INIT "")
-set (CMAKE_CXX_FLAGS_INIT "-fvisibility=hidden -fvisibility-inlines-hidden")
+set (CMAKE_CXX_FLAGS_INIT "")
 
 set (CMAKE_C_LINK_FLAGS "-Wl,-search_paths_first ${CMAKE_C_LINK_FLAGS}")
 set (CMAKE_CXX_LINK_FLAGS "-Wl,-search_paths_first ${CMAKE_CXX_LINK_FLAGS}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required (VERSION 3.7)
+
+set(TEST_SOURCE
+    ${CMAKE_CURRENT_LIST_DIR}/Tests.m
+)
+
+xctest_add_bundle(${TEST_NAME}
+    ${APP_NAME}
+    ${TEST_SOURCE}
+)
+
+if(NOT LOGIC_ONLY_TESTS)
+    target_include_directories(${TEST_NAME} PUBLIC
+        "${CMAKE_SOURCE_DIR}"
+    )
+endif(NOT LOGIC_ONLY_TESTS)
+
+xctest_add_test(${TEST_BUNDLE_IDENTIFIER}
+    ${TEST_NAME}
+)
+
+set(CMAKE_SHARED_LINKER_FLAGS "-Wall")
+
+set_target_properties(${TEST_NAME} PROPERTIES
+    MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_LIST_DIR}/tests.plist.in
+    XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET ${DEPLOYMENT_TARGET}
+    XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ${CODE_SIGN_IDENTITY}
+    XCODE_ATTRIBUTE_DEVELOPMENT_TEAM ${DEVELOPMENT_TEAM_ID}
+    XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY ${DEVICE_FAMILY}
+    XCODE_ATTRIBUTE_FRAMEWORK_SEARCH_PATHS "\$(inherited)"
+)
+
+if(LOGIC_ONLY_TESTS)
+    set_target_properties(${TEST_NAME} PROPERTIES
+        XCODE_ATTRIBUTE_TEST_HOST ""
+    )
+endif(LOGIC_ONLY_TESTS)
+
+# This is needed to erase invalid framework search paths set by FindXCTest.
+# The drawback is that you can not use target_include_directories for setting up
+# search paths for this target. You have to use
+# XCODE_ATTRIBUTE_FRAMEWORK_SEARCH_PATHS. As long as you stick to running
+# tests on code compiled into the host app this is not a hindrance.
+set_target_properties(${TEST_NAME} PROPERTIES
+    XCODE_ATTRIBUTE_FRAMEWORK_SEARCH_PATHS "\$(inherited) "
+)

--- a/tests/Tests.m
+++ b/tests/Tests.m
@@ -1,0 +1,23 @@
+#import <XCTest/XCTest.h>
+
+#import "CppInterface.h"
+
+@interface Tests : XCTestCase
+@end
+
+@implementation Tests
+
+- (void)setUp {
+    [super setUp];
+}
+
+- (void)tearDown {
+    [super tearDown];
+}
+
+- (void)testExample {
+    CppInterface* i = [[CppInterface alloc] init];
+    XCTAssert(i);
+}
+
+@end

--- a/tests/tests.plist.in
+++ b/tests/tests.plist.in
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>


### PR DESCRIPTION
1.  Host application and pure logic tests are now possible.
2.  ios.cmake toolchain had to be modified to disable symbol hiding.
3.  Default cmake module FindXCTest is now used to create test bundle.
4.  Some comments have been tweaked.